### PR TITLE
adding app versioning display code

### DIFF
--- a/ckanext/csiro_hub_theme/plugin.py
+++ b/ckanext/csiro_hub_theme/plugin.py
@@ -1,9 +1,18 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+from ckan.common import config
+
+
+def appversion():
+    '''Returns the appversion config value.'''
+
+    value = config.get('ckan.appversion', 'unknown')
+    return value
 
 
 class Csiro_Hub_ThemePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
+    plugins.implements(plugins.ITemplateHelpers)
 
     # IConfigurer
 
@@ -11,3 +20,13 @@ class Csiro_Hub_ThemePlugin(plugins.SingletonPlugin):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'csiro_hub_theme')
+
+    def get_helpers(self):
+        '''Register the most_popular_groups() function above as a template
+        helper function.
+
+        '''
+        # Template helper function names should begin with the name of the
+        # extension they belong to, to avoid clashing with functions from
+        # other extensions.
+        return {'appversion': appversion}

--- a/ckanext/csiro_hub_theme/templates/home/snippets/about_text.html
+++ b/ckanext/csiro_hub_theme/templates/home/snippets/about_text.html
@@ -51,7 +51,9 @@ or feel free to contact us at <a href="mailto:lw-dam-support@csiro.au">lw-dam-su
 	David Lemon,
 	Sally Tetreault-Campbell
 </p>
+
 </div>
 
 
 {% endtrans %}
+<p>App version: {{ h.appversion()}} </p>


### PR DESCRIPTION
This PR adds code that allows the `ckan.appversion` config variable in CKAN displayed in the about page.